### PR TITLE
Remove wrapper div

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -36,7 +36,7 @@ class ClickOutComponent extends React.Component {
   }
 
   render() {
-    return <div>{this.props.children}</div>;
+    return React.Children.only(this.props.children);
   }
 }
 


### PR DESCRIPTION
Wrapper div makes it hard to wrap divs that are absolutely or relatively positioned as it adds an extra normal div around them