### PR TITLE
Add support for React 0.14

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var React = require('react');
+var ReactDOM = require('react-dom');
 
 var ClickOutComponent = (function (_React$Component) {
   _inherits(ClickOutComponent, _React$Component);
@@ -23,7 +24,7 @@ var ClickOutComponent = (function (_React$Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       var self = this,
-          el = React.findDOMNode(this),
+          el = ReactDOM.findDOMNode(this),
           reactId = el.getAttribute('data-reactid');
 
       self.__windowListener = function (e) {
@@ -48,7 +49,7 @@ var ClickOutComponent = (function (_React$Component) {
     key: 'componentWillUnmount',
     value: function componentWillUnmount() {
       window.removeEventListener('click', this.__windowListener);
-      React.findDOMNode(this).removeEventListener('click', this.__elementListener);
+      ReactDOM.findDOMNode(this).removeEventListener('click', this.__elementListener);
     }
   }, {
     key: 'render',

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://github.com/boblauer/react-onclickout#readme",
   "peerDependencies": {
-    "react": ">=0.12"
+    "react": ">=0.14",
+    "react-dom": ">=0.14"
   },
   "devDependencies": {
     "babel": "^5.8.20",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 const React = require('react');
+const ReactDOM = require('react-dom');
 
 class ClickOutComponent extends React.Component {
 
@@ -10,7 +11,7 @@ class ClickOutComponent extends React.Component {
 
   componentDidMount() {
     let self    = this
-      , el      = React.findDOMNode(this)
+      , el      = ReactDOM.findDOMNode(this)
       , reactId = el.getAttribute('data-reactid')
       ;
 
@@ -35,7 +36,7 @@ class ClickOutComponent extends React.Component {
 
   componentWillUnmount() {
     window.removeEventListener('click', this.__windowListener);
-    React.findDOMNode(this).removeEventListener('click', this.__elementListener);
+    ReactDOM.findDOMNode(this).removeEventListener('click', this.__elementListener);
   }
 
   render() {

--- a/test/index.jsx
+++ b/test/index.jsx
@@ -1,6 +1,7 @@
 var assert          = require('assert')
   , jsdom           = require('jsdom')
   , React           = require('react')
+  , ReactDOM        = require('react-dom')
   , ClickOutWrapper = require('../index.js')
   , clickedOutCount = 0
   ;
@@ -17,7 +18,7 @@ describe('ClickOutWrapper', function () {
   });
 
   it('works as a wrapper component', function() {
-    React.render(
+    ReactDOM.render(
       <ClickOutWrapper onClickOut={incrementClickedOutCount}>
         <span className='click-in'>Click in!</span>
       </ClickOutWrapper>, document.body
@@ -29,7 +30,7 @@ describe('ClickOutWrapper', function () {
   });
 
   it('works as a wrapper component with multiple children', function() {
-    React.render(
+    ReactDOM.render(
       <ClickOutWrapper onClickOut={incrementClickedOutCount}>
         <span className='click-in'>Click in!</span>
         <span className='click-in-2'>Click in!</span>
@@ -42,7 +43,7 @@ describe('ClickOutWrapper', function () {
   })
 
   it('works with multiple instances at once', function() {
-    React.render(
+    ReactDOM.render(
       <div>
         <ClickOutWrapper onClickOut={incrementClickedOutCount}>
           <span className='click-in'>Click in!</span>
@@ -59,7 +60,7 @@ describe('ClickOutWrapper', function () {
   });
 
   it('cleans up handlers as a wrapper component', function() {
-    React.render(
+    ReactDOM.render(
       <ClickOutWrapper onClickOut={incrementClickedOutCount}>
         <span className='click-in'>Click in!</span>
       </ClickOutWrapper>, document.body
@@ -69,7 +70,7 @@ describe('ClickOutWrapper', function () {
 
     testClicks();
 
-    var unmounted = React.unmountComponentAtNode(document.body);
+    var unmounted = ReactDOM.unmountComponentAtNode(document.body);
     assert.equal(unmounted, true);
 
     appendClickOutArea(document.body);
@@ -88,7 +89,7 @@ describe('ClickOutWrapper', function () {
       }
     }
 
-    React.render(React.createElement(Component), document.body);
+    ReactDOM.render(React.createElement(Component), document.body);
     appendClickOutArea(document.body);
 
     testClicks();
@@ -105,12 +106,12 @@ describe('ClickOutWrapper', function () {
       }
     }
 
-    React.render(React.createElement(Component), document.body);
+    ReactDOM.render(React.createElement(Component), document.body);
     appendClickOutArea(document.body);
 
     testClicks();
 
-    var unmounted = React.unmountComponentAtNode(document.body);
+    var unmounted = ReactDOM.unmountComponentAtNode(document.body);
     assert.equal(unmounted, true);
 
     appendClickOutArea(document.body);


### PR DESCRIPTION
This converts the following calls to use `react-dom` (which is added as a peer-dependency):

```js
React.render()
React.findDOMNode()
React.unmountComponentAtNode
```

All tests are passing on my machine with Node v0.10.9. The only issue is the warning for rendering into `document.body` added in 0.14.

```
Warning: render(): Rendering components directly into document.body is discour
aged, since its children are often manipulated by third-party scripts and brow
ser extensions. This may lead to subtle reconciliation issues. Try rendering i
nto a container element created for your app.
```